### PR TITLE
Update myst/latex support.

### DIFF
--- a/deployments/stat159/image/apt.txt
+++ b/deployments/stat159/image/apt.txt
@@ -38,12 +38,16 @@ build-essential
 gfortran
 
 # Dependencies for nbconvert and myst
-# Latex tools
+# LaTeX tools
 texlive-xetex
 texlive-plain-generic
 texlive-fonts-extra
 texlive-fonts-recommended
 texlive-lang-chinese
+texlive-latex-extra
+texlive-latex-recommended
+texlive-humanities
+texlive-music
 texlive-science
 latexmk
 lmodern
@@ -51,8 +55,8 @@ latexdiff
 
 # Other useful document-related tools
 pandoc
-imagemagick# /end nbconvert/myst tools
-
+imagemagick
+# /end nbconvert/myst tools
 
 # Some useful git utilities use basic Ruby
 ruby

--- a/deployments/stat159/image/environment.yml
+++ b/deployments/stat159/image/environment.yml
@@ -41,6 +41,7 @@ dependencies:
   - jupyterlab-git==0.41.0
   - jupyterlab-link-share==0.2.5
   - jupyterlab-variableinspector==3.0.9
+  - jupyterlab-myst==1.1.0
   - jupyterlab_pygments==0.2.2
   - jupyterlab_server==2.19.0
   - jupyterlab_widgets==3.0.5
@@ -104,7 +105,6 @@ dependencies:
 # Packages not available on conda-forge, installed through pip
   - pip:
     - ipython-sql==0.4.1
-    - jupyterlab_myst==1.0.1
     
     # Packages needed only on the hub (mostly linux)
     # If installing this environment on a personal machine, 


### PR DESCRIPTION
- New version of myst, and now available from conda-forge, so we don't need to use pip anymore for it.
- Update the LaTeX installation to support more use cases (myst in particular uses some additional styles not in the base package).